### PR TITLE
Possible regex upgrade

### DIFF
--- a/Assets/Editor/TestTextureImporter.cs
+++ b/Assets/Editor/TestTextureImporter.cs
@@ -30,7 +30,7 @@ public class TestTextureIporter : AssetPostprocessor {
 	{
 		string extension = Path.GetExtension(assetPath);
 		string filenameWithoutExtention = Path.GetFileNameWithoutExtension(assetPath);
-		var match = Regex.Match(filenameWithoutExtention, @".mip(\d)+$");
+		var match = Regex.Match(filenameWithoutExtention, @"\.mip(\d{1,2})$");
 
 		if(match.Success)
 		{


### PR DESCRIPTION
Limit the mip number between 1 and 99 (should be enough mips) and make sure it ends with .mip and not any letter followed by mip.